### PR TITLE
Respect original author existence in `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,24 @@
     "clean:linux": "rm sources/app/*.js*"
   },
   "author": {
-    "name": "Descendo The Monkei#0624",
-    "email": "github@descendo.anonaddy.me",
-    "url": "https://github.com/Monkei-Cord"
+    "name": "SpacingBat3",
+    "email": "git@spacingbat3.anonaddy.com",
+    "url": "https://github.com/SpacingBat3"
   },
+  "maintainers": [
+    {
+      "name": "Descendo The Monkei#0624",
+      "email": "github@descendo.anonaddy.me",
+      "url": "https://github.com/Monkei-Cord"
+    }
+  ],
+  "contributors":[
+    {
+      "name": "Descendo The Monkei#0624",
+      "email": "github@descendo.anonaddy.me",
+      "url": "https://github.com/Monkei-Cord"
+    }
+  ], 
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
At WebCord, I reserved `author` field to express that I'm the original author of this application and let `contributors` field for others (fork authors/maintainers etc.). There's also a `maintainers` field in Node.js specification that lists a current people maintaining this application. You should use these two IMO if you want to respect that I'm the original author of this software

If you don't like this, you should add me to the `contributors` list instead (like AUR `PKGBUILD` rules, but modify the code so the `about` panel also shows my own copyright notice next to yours. This should let people to be less confused about who made this software.

I will also discourage you removing anything from the license file, it may result in the project's takedown or the copyright infringement. You're free to add your own copyright notice as well as any notes about which part of the code is copyrighted by me and which is yours. At the time I have written this comment, **I'm the author of the whole code**, maybe except some rebranded fields 😉.